### PR TITLE
Adding default cache control

### DIFF
--- a/lib/HTTP/Caching.pm
+++ b/lib/HTTP/Caching.pm
@@ -221,8 +221,14 @@ sub make_request {
     croak __PACKAGE__ . " request is not a HTTP::Request object [$original_request]"
         unless $original_request->isa('HTTP::Request');
     
-    return $self->_forward($original_request, @_) unless $self->cache;
-    
+    unless ($self->cache) {
+        my $modified_request =
+            $self->_modifiy_cache_control_request($original_request);
+        my $retrieved_response = $self->_forward($modified_request, @_);
+        my $modified_response =
+            $self->_modifiy_cache_control_response($retrieved_response);
+        return $modified_response;
+    }
     
     # How did we end up here ?
     carp __PACKAGE__ . 'runaway';
@@ -241,6 +247,16 @@ sub _forward {
         unless $forward_resp->isa('HTTP::Response');
     
     return $forward_resp;
+}
+
+sub _modifiy_cache_control_request {
+    my $self = shift;
+    return shift->clone;
+}
+
+sub _modifiy_cache_control_response {
+    my $self = shift;
+    return shift->clone;
 }
 
 1;

--- a/t/00_use_ok_and_methods.t
+++ b/t/00_use_ok_and_methods.t
@@ -20,8 +20,8 @@ my $chi_cache = CHI->new(
     }
 );
 
-my $original_rqst = HTTP::Request->new();
-$original_rqst->method('TEST'); # yep, does not exists, thats fine
+my $request = HTTP::Request->new();
+$request->method('TEST'); # yep, does not exists, thats fine
 
 
 subtest 'Instantiating HTTP::Caching object' => sub {
@@ -31,7 +31,7 @@ subtest 'Instantiating HTTP::Caching object' => sub {
     new_ok('HTTP::Caching', [
             cache                   => $chi_cache,
             cache_type              => 'private',
-            cache_request_control   => [ 'max-age=3600' ],
+            cache_request_control   => 'max-age=3600',
             forwarder               => sub { return HTTP::Response->new(100) }
         ] , 'my $http_caching'
     );
@@ -52,8 +52,8 @@ subtest 'HTTP::Caching make_request' => sub {
     can_ok($http_caching, 'make_request');
     
 
-    my $original_resp = $http_caching->make_request($original_rqst);
-    ok($original_resp->is_info,
+    my $response = $http_caching->make_request($request);
+    ok($response->is_info,
         '... and we can continue');
     
     eval {$http_caching->make_request};
@@ -90,10 +90,10 @@ subtest 'HTTP::Caching forwarding' => sub {
         return $forward_resp;
     }
     
-    my $retrieved_resp = $http_caching->make_request($original_rqst);
-    isa_ok ($retrieved_resp, 'HTTP::Response',
+    my $response = $http_caching->make_request($request);
+    isa_ok ($response, 'HTTP::Response',
         'forwarded response back');
-    is($retrieved_resp->message, 'Yay!',
+    is($response->message, 'Yay!',
         '... with the message: "Yay!"');
     
     my $errs_caching = eval {
@@ -104,15 +104,9 @@ subtest 'HTTP::Caching forwarding' => sub {
         )
     };
     
-    eval {$errs_caching->make_request($original_rqst) };
+    eval {$errs_caching->make_request($request) };
     like($@, qr/HTTP::Caching response from forwarder/,
         '... but do not allow bad responses');
 
 
 };
-
-
-
-
-
-

--- a/t/01_modify_cache_control_headers.t
+++ b/t/01_modify_cache_control_headers.t
@@ -1,0 +1,36 @@
+use Test::Most tests => 1;
+
+use HTTP::Caching;
+
+use HTTP::Request;
+use HTTP::Response;
+
+subtest 'Simple modifiactions' => sub {
+    plan tests => 3;
+    
+    my $http_caching =
+    new_ok('HTTP::Caching', [
+            cache                   => undef,
+            cache_type              => 'private',
+            cache_control_request   => 'min-fresh=60',
+            cache_control_response  => 'must-revalidate',
+            forwarder               => sub {
+                my $forward_rqst = shift;
+                my $directive = $forward_rqst->header('cache-control');
+                
+                is($directive, 'min-fresh=60', 'modified request');
+                
+                return HTTP::Response->new(100)
+            },
+        ] , 'my $http_caching'
+    );
+    
+    my $request = HTTP::Request->new();
+    $request->method('TEST');
+    
+    my $response = $http_caching->make_request($request);
+    
+    my $directive = $response->header('cache-control');
+    is($directive, 'must-revalidate', 'modified response');
+    
+}


### PR DESCRIPTION
currently allows Cache-Control header field be inserted in the request or response headers.

future implementations might be more intelligent and merge with already existing directives