### PR TITLE
Naive store in cache

### DIFF
--- a/lib/HTTP/Caching.pm
+++ b/lib/HTTP/Caching.pm
@@ -10,6 +10,8 @@ use strict;
 use warnings;
 
 use Carp;
+use Digest::MD5;
+use Time::HiRes;
 
 use HTTP::Response;
 
@@ -236,7 +238,21 @@ sub make_request {
         my $response =
             $self->_modify_response_cache_control($forwarded_resp);
         
-        return $response;
+        return $response
+    } else {
+        # add the default Cache-Control request header-field
+        my $forwarded_rqst =
+            $self->_modify_request_cache_control($presented_request);
+        
+        my $forwarded_resp = $self->_forward($forwarded_rqst, @params);
+        
+        $self->_store_request_with_response($forwarded_rqst, $forwarded_resp);
+        
+        # add the default Cache-Control response header-field
+        my $response =
+            $self->_modify_response_cache_control($forwarded_resp);
+        
+        return $response
     }
     
     # How did we end up here ?
@@ -249,15 +265,48 @@ sub make_request {
 sub _forward {
     my $self = shift;
     
-    my $forward_rqst = shift;
+    my $forwarded_rqst = shift;
     
-    my $forward_resp = $self->forwarder->($forward_rqst, @_);
+    my $forwarded_resp = $self->forwarder->($forwarded_rqst, @_);
     
     croak __PACKAGE__
-        . " response from forwarder is not a HTTP::Response [$forward_resp]"
-        unless $forward_resp->isa('HTTP::Response');
+        . " response from forwarder is not a HTTP::Response [$forwarded_resp]"
+        unless $forwarded_resp->isa('HTTP::Response');
     
-    return $forward_resp;
+    return $forwarded_resp;
+}
+
+sub _store_request_with_response {
+    my $self        = shift;
+    my $rqst        = shift->clone or croak ;
+    my $resp        = shift->clone or die;
+    
+    my $content_key = $self->_store_response_content($resp);
+    my $request_key = Digest::MD5::md5_hex($rqst->uri()->as_string);
+    
+    $self->cache->set($request_key,
+        {
+            rqst        => $rqst,
+            resp        => $resp,
+            content_key => $content_key
+        }
+    );
+    
+}
+
+sub _store_response_content {
+    my $self        = shift;
+    my $resp        = shift;
+    
+    my $content_key = Digest::MD5::md5_hex(Time::HiRes::time());
+    
+    eval { $self->cache->set( $content_key, $resp->content() ) };
+    return $content_key unless $@;
+    
+    croak __PACKAGE__
+        . " could not store content in cache with key [$content_key], $@";
+    
+    return
 }
 
 sub _modify_request_cache_control {

--- a/t/02_store_respone.t
+++ b/t/02_store_respone.t
@@ -1,0 +1,61 @@
+use Test::Most tests => 2;
+
+use HTTP::Caching;
+
+use CHI;
+use HTTP::Request;
+use HTTP::Response;
+
+use Readonly;
+
+# Although it does look like a proper URI, no, the file does not need to exist.
+Readonly my $URI_LOCATION  => 'file:///tmp/HTTP_Cacing/greetings.txt';
+Readonly my $URI_MD5       => '7d3d0fc115036f144964caafaf2c7df2';
+
+my $chi_cache = CHI->new(
+    driver                  => 'File',
+    root_dir                => '/tmp/HTTP_Caching',
+    file_extension          => '.cache',
+    l1_cache                => {
+        driver                  => 'Memory',
+        global                  => 1,
+        max_size                => 1024*1024
+    }
+);
+
+my $request = HTTP::Request->new();
+$request->method('TEST'); # yep, does not exists, thats fine
+$request->uri($URI_LOCATION);
+
+# 501 Not Implemented is a 'by default' cachable response
+#
+# See RFC 7234 Section 3.     Storing Responses in Cach
+#                               The response either has ... a statuscode
+#     RFC 7234 Section 4.2.2. Calculating Heuristic Freshness
+#     RFC 7231 Section 6.1.   Overview of Status Codes
+#                      6.6.2. 501 Not Implemented
+#
+# This means that without any other Cache-control directives, or Expires or
+# Last-Modified, this response can always be stored in the cache
+#
+my $forwarded_resp = HTTP::Response->new(501);
+$forwarded_resp->content('Hello World!');
+
+my $http_caching = HTTP::Caching->new(
+    cache                   => $chi_cache,
+    cache_type              => 'private',
+    cache_request_control   => 'max-age=3600',
+    forwarder               => sub { return $forwarded_resp }
+);
+
+$http_caching->make_request($request);
+
+my $stored_l1 = $chi_cache->get($URI_MD5);
+
+my $stored_content = $chi_cache->get( $stored_l1->{content_key} );
+is ($chi_cache->get( $stored_l1->{content_key} ), 'Hello World!',
+    'Stored response content' );
+
+my $stored_status = $stored_l1->{resp}->code;
+is ($stored_l1->{resp}->code, '501',
+    'Stored response header');


### PR DESCRIPTION
using a 501: Not implemented response, we can safely store these and try to get them in a later stadium.

This is a naive approach since it does not consider the RFC 7234 specs. Except, maybe, the fact that 501 can be stored anyways