### PR TITLE
Naive retrieve from cache

### DIFF
--- a/lib/HTTP/Caching.pm
+++ b/lib/HTTP/Caching.pm
@@ -240,6 +240,11 @@ sub make_request {
         
         return $response
     } else {
+        # check if there is a cached version
+        my $chi_cache_resp =
+            $self->_retrieve_response_for_request($presented_request);
+        return $chi_cache_resp if $chi_cache_resp;
+        
         # add the default Cache-Control request header-field
         my $forwarded_rqst =
             $self->_modify_request_cache_control($presented_request);
@@ -320,15 +325,19 @@ sub _retrieve_response_for_request {
     my $self        = shift;
     my $rqst        = shift;
     
+    # check cache for stored meta-data 
     my $request_key = Digest::MD5::md5_hex($rqst->uri()->as_string);
     my $meta_data   = $self->cache->get( $request_key );
+    return unless $meta_data;
+    
+    # check cache for content
     my $content_key = $meta_data->{content_key};
-    
     my $content = $self->_retrieve_content($content_key);
+    return unless $content;
     
+    # compose response
     my $resp = $meta_data->{stripped_resp};
     my $resp_clone = $resp->clone;
-    
     $resp_clone->content($content);
     
     return $resp_clone

--- a/lib/HTTP/Caching.pm
+++ b/lib/HTTP/Caching.pm
@@ -316,6 +316,37 @@ sub _store_content {
     return
 }
 
+sub _retrieve_response_for_request {
+    my $self        = shift;
+    my $rqst        = shift;
+    
+    my $request_key = Digest::MD5::md5_hex($rqst->uri()->as_string);
+    my $meta_data   = $self->cache->get( $request_key );
+    my $content_key = $meta_data->{content_key};
+    
+    my $content = $self->_retrieve_content($content_key);
+    
+    my $resp = $meta_data->{stripped_resp};
+    my $resp_clone = $resp->clone;
+    
+    $resp_clone->content($content);
+    
+    return $resp_clone
+}
+
+sub _retrieve_content {
+    my $self        = shift;
+    my $content_key = shift;
+    
+    my $content = eval { $self->cache->get( $content_key ) };
+    return $content unless $@;
+    
+    croak __PACKAGE__
+        . " could not retrieve content from cache with key [$content_key], $@";
+    
+    return
+}
+
 sub _modify_request_cache_control {
     my $self        = shift;
     my $rqst        = shift;

--- a/t/03_retrieve_response.t
+++ b/t/03_retrieve_response.t
@@ -1,0 +1,70 @@
+use Test::Most tests => 6;
+
+use HTTP::Caching;
+
+use CHI;
+use HTTP::Request;
+use HTTP::Response;
+
+use Readonly;
+
+# Although it does look like a proper URI, no, the file does not need to exist.
+Readonly my $URI_LOCATION   => 'file:///tmp/HTTP_Cacing/greetings.txt';
+Readonly my $URI_MD5        => '7d3d0fc115036f144964caafaf2c7df2';
+Readonly my $CONTENT_KEY    => '3e5f1b953da8430c6f88b90ac15d78fa'; # or whatever
+
+my $chi_cache = CHI->new(
+    driver                  => 'File',
+    root_dir                => '/tmp/HTTP_Caching',
+    file_extension          => '.cache',
+    l1_cache                => {
+        driver                  => 'Memory',
+        global                  => 1,
+        max_size                => 1024*1024
+    }
+);
+
+my $request = HTTP::Request->new();
+$request->method('TEST'); # yep, does not exists, thats fine
+$request->uri($URI_LOCATION);
+$request->content('knock knock ...');
+
+# 501 Not Implemented is a 'by default' cachable response
+#
+# See RFC 7234 Section 3.     Storing Responses in Cach
+#                               The response either has ... a statuscode
+#     RFC 7234 Section 4.2.2. Calculating Heuristic Freshness
+#     RFC 7231 Section 6.1.   Overview of Status Codes
+#                      6.6.2. 501 Not Implemented
+#
+# This means that without any other Cache-control directives, or Expires or
+# Last-Modified, this response can always be stored in the cache
+#
+my $expected_resp = HTTP::Response->new(501);
+$expected_resp->content('Who is there');
+
+my $rqst_clone = $request->clone;
+$rqst_clone->content(undef);
+my $resp_clone = $expected_resp->clone;
+$resp_clone->content(undef);
+
+# populate the cache, we could try mocking CHI, but I'm to lazy for that
+$chi_cache->set($CONTENT_KEY, 'Who is there?');
+$chi_cache->set($URI_MD5,
+    {
+        stripped_rqst   => $rqst_clone,
+        stripped_resp   => $resp_clone,
+        content_key     => $CONTENT_KEY,
+    }
+);
+
+my $http_caching = HTTP::Caching->new(
+    cache                   => $chi_cache,
+    cache_type              => 'private',
+    forwarder               => sub { return undef } # we should ewnd up here
+);
+
+my $response = $http_caching->make_request($request);
+
+use DDP; p $response;
+

--- a/t/04_naive_roundtrip.t
+++ b/t/04_naive_roundtrip.t
@@ -1,0 +1,59 @@
+use Test::Most tests => 4;
+
+use HTTP::Caching;
+
+use CHI;
+use HTTP::Request;
+use HTTP::Response;
+
+use Readonly;
+
+# Although it does look like a proper URI, no, the file does not need to exist.
+Readonly my $URI_LOCATION   => 'file:///tmp/HTTP_Cacing/greetings.txt';
+Readonly my $URI_MD5        => '7d3d0fc115036f144964caafaf2c7df2';
+Readonly my $CONTENT_KEY    => '3e5f1b953da8430c6f88b90ac15d78fa'; # or whatever
+
+my $chi_cache = CHI->new(
+    driver                  => 'Memory',
+    global                  => 0,
+    l1_cache                => {
+        driver                  => 'Memory',
+        global                  => 0,
+        max_size                => 1024*1024
+    }
+);
+
+my $request = HTTP::Request->new();
+$request->method('TEST');
+$request->uri($URI_LOCATION);
+$request->content('knock knock ...');
+
+# 501 Not Implemented is a 'by default' cachable response
+my $forwarded_resp = HTTP::Response->new(501);
+$forwarded_resp->content('Who is there?');
+
+my $forwarded_rqst = undef; # flag to be set if we do forward the request
+
+my $http_caching = HTTP::Caching->new(
+    cache                   => $chi_cache,
+    cache_type              => 'private',
+    forwarder               => sub {
+        $forwarded_rqst = shift;
+        return $forwarded_resp
+    }
+);
+
+my $response_one = $http_caching->make_request($request);
+is ($forwarded_rqst->content(), 'knock knock ...',
+    "Request has been forwarded");
+is ($response_one->content(), 'Who is there?',
+    "... and response one is as expected" );
+
+$forwarded_rqst = undef;
+
+my $response_two = $http_caching->make_request($request);
+is ($forwarded_rqst, undef,
+    "Request has not been forwarded for the second time");
+is ($response_one->content(), 'Who is there?',
+    "... and response two is as expected" );
+


### PR DESCRIPTION
This makes it possible to use the module in a very rudimentary state, it stores responses in the cache and will use them if a requests comes in with the same uri.

no fancy checks are done as described in RFC7234