### PR TITLE
Removing cache complexity

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,12 +16,12 @@ WriteMakefile(
     },
     BUILD_REQUIRES => {
         'Test::Most'                    => 0,
+        'Test::MockObject'              => 0,
         'HTTP::Request'                 => 0,
         'HTTP::Response'                => 0,
         'Readonly'                      => 0,
     },
     PREREQ_PM => {
-        'CHI'                           => 0,
         'Carp'                          => 0,
         'Digest::MD5'                   => 0,
         'Time::HiRes'                   => 0,

--- a/t/00_use_ok_and_methods.t
+++ b/t/00_use_ok_and_methods.t
@@ -1,6 +1,6 @@
 use Test::Most tests => 4;
+use Test::MockObject;
 
-use CHI;
 use HTTP::Request;
 use HTTP::Response;
 
@@ -9,27 +9,21 @@ subtest 'HTTP::Caching' => sub {
     use_ok('HTTP::Caching');
 };
 
-my $chi_cache = CHI->new(
-    driver                  => 'File',
-    root_dir                => '/tmp/HTTP_Caching',
-    file_extension          => '.cache',
-    l1_cache                => {
-        driver                  => 'Memory',
-        global                  => 1,
-        max_size                => 1024*1024
-    }
-);
+# mock cache
+my %cache;
+my $mocked_cache = Test::MockObject->new;
+$mocked_cache->mock( set => sub { } );
+$mocked_cache->mock( get => sub { } );
 
 my $request = HTTP::Request->new();
 $request->method('TEST'); # yep, does not exists, thats fine
-
 
 subtest 'Instantiating HTTP::Caching object' => sub {
     plan tests => 1;
     
     my $http_caching =
     new_ok('HTTP::Caching', [
-            cache                   => $chi_cache,
+            cache                   => $mocked_cache,
             cache_type              => 'private',
             cache_request_control   => 'max-age=3600',
             forwarder               => sub { return HTTP::Response->new(501) }

--- a/t/03_retrieve_response.t
+++ b/t/03_retrieve_response.t
@@ -1,8 +1,8 @@
 use Test::Most tests => 1;
+use Test::MockObject;
 
 use HTTP::Caching;
 
-use CHI;
 use HTTP::Request;
 use HTTP::Response;
 
@@ -11,17 +11,12 @@ use Readonly;
 # Although it does look like a proper URI, no, the file does not need to exist.
 Readonly my $URI_LOCATION   => 'file:///tmp/HTTP_Cacing/greetings.txt';
 Readonly my $URI_MD5        => '7d3d0fc115036f144964caafaf2c7df2';
-Readonly my $CONTENT_KEY    => '3e5f1b953da8430c6f88b90ac15d78fa'; # or whatever
 
-my $chi_cache = CHI->new(
-    driver                  => 'Memory',
-    global                  => 1,
-    l1_cache                => {
-        driver                  => 'Memory',
-        global                  => 0,
-        max_size                => 1024*1024
-    }
-);
+# mock cache
+my %cache;
+my $mocked_cache = Test::MockObject->new;
+$mocked_cache->mock( set => sub { } );
+$mocked_cache->mock( get => sub { return $cache{$_[1]} } );
 
 my $request = HTTP::Request->new();
 $request->method('TEST'); # yep, does not exists, thats fine
@@ -31,22 +26,11 @@ $request->content('knock knock ...');
 my $expected_resp = HTTP::Response->new(501);
 $expected_resp->content('Who is there?');
 
-my $rqst_clone = $request->clone;
-$rqst_clone->content(undef);
-my $resp_clone = $expected_resp->clone;
-$resp_clone->content(undef);
-
 # populate the cache, we could try mocking CHI, but I'm to lazy for that
-$chi_cache->set( $CONTENT_KEY => 'Who is there?' );
-$chi_cache->set( $URI_MD5 => {
-        stripped_rqst   => $rqst_clone,
-        stripped_resp   => $resp_clone,
-        content_key     => $CONTENT_KEY,
-    }
-);
+$cache{$URI_MD5} = $expected_resp;
 
 my $http_caching = HTTP::Caching->new(
-    cache                   => $chi_cache,
+    cache                   => $mocked_cache,
     cache_type              => 'private',
     forwarder               => sub { die "we shouldn't be here!" }
 );
@@ -54,5 +38,4 @@ my $http_caching = HTTP::Caching->new(
 my $response = $http_caching->make_request($request);
 
 is ( $response->content(), 'Who is there?',
-    "Got the expected 'contructed' response back");
-    
+    "Got the expected response back");


### PR DESCRIPTION
When being naive, why bother about L1 caches etc. We no longer are relying on CHI (potentially removing Moo as a dependency in the future). We only need that $cache does implement ways to `set` and `get` data with a given key.... for now