### PR TITLE
Two level caching

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -9,4 +9,5 @@ t/01_modify_cache_control_headers.t
 t/02_store_respone.t
 t/03_retrieve_response.t
 t/04_naive_roundtrip.t
+t/05_may_store_in_cache.t
 ignore.txt

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,7 +25,7 @@ WriteMakefile(
         'Carp'                          => 0,
         'Digest::MD5'                   => 0,
         'HTTP::Method'                  => 0,
-        'Monky::Patch::Action'          => 0,
+        'Monkey::Patch::Action'         => 0,
         'Moo'                           => 0,
         'MooX::Types::MooseLike::Base'  => 0,
         'Time::HiRes'                   => 0,

--- a/lib/HTTP/Caching.pm
+++ b/lib/HTTP/Caching.pm
@@ -300,6 +300,25 @@ sub _forward {
     return $forwarded_resp;
 }
 
+
+=head1 ABOUT CACHING
+
+If one would read the RFC7234 Section 2. Overview of Cache Operation, it becomes
+clear that a cache can hold multiple responses for the same URI. Caches that
+conform to CHI and many others, typically use a key / value storage. But this
+will become a problem as that it can not use the URI as a key to the various
+responses.
+
+The way it is solved is to create an intermediate meta-dictionary. This can be
+stored by URI as key. Each response will simply be stored with a unique key and
+these keys will be used as the entries in the dictionary.
+
+The meta-dictionary entries will hold (relevant) request and response headers so
+that it willbe more quick to figure wich entrie can be used. Otherwise we would
+had to read the entire responses to analyze them.
+
+=cut
+
 # _store may or may not store the response into the cache
 #
 # depending on the response it _may_store_in_cache()

--- a/lib/HTTP/Caching.pm
+++ b/lib/HTTP/Caching.pm
@@ -332,7 +332,16 @@ sub _store {
     
     if ( my $resp_key = $self->_store_response($resp) ) {
         my $rqst_key = Digest::MD5::md5_hex($rqst->uri()->as_string);
-        $self->_insert_meta_dict( $rqst_key, $resp_key );
+        my $rsqt_stripped = $rqst->clone; $rsqt_stripped->content(undef);
+        my $resp_stripped = $resp->clone; $resp_stripped->content(undef);
+        $self->_insert_meta_dict(
+            $rqst_key,
+            $resp_key,
+            {
+                resp_stripped   => $resp_stripped,
+                rqst_stripped   => $rsqt_stripped,
+            },
+        );
         return $resp_key;
     }
     

--- a/lib/HTTP/Caching.pm
+++ b/lib/HTTP/Caching.pm
@@ -6,11 +6,11 @@ HTTP::Caching - The RFC 7234 compliant brains to do caching right
 
 =head1 VERSION
 
-Version 0.02 Alpha 03
+Version 0.02 Alpha 04
 
 =cut
 
-our $VERSION = '0.02_03';
+our $VERSION = '0.02_04';
 
 use strict;
 use warnings;

--- a/lib/HTTP/Caching.pm
+++ b/lib/HTTP/Caching.pm
@@ -6,11 +6,11 @@ HTTP::Caching - The RFC 7234 compliant brains to do caching right
 
 =head1 VERSION
 
-Version 0.02 Alpha 02
+Version 0.02 Alpha 03
 
 =cut
 
-our $VERSION = '0.02_02';
+our $VERSION = '0.02_03';
 
 use strict;
 use warnings;

--- a/t/01_modify_cache_control_headers.t
+++ b/t/01_modify_cache_control_headers.t
@@ -49,5 +49,4 @@ subtest 'Simple modifiactions' => sub {
     is($response->header('cache-control'), 'no-store, must-revalidate',
         "modified response with existing directives");
     
-
 }

--- a/t/02_store_respone.t
+++ b/t/02_store_respone.t
@@ -23,7 +23,7 @@ $mocked_cache->mock( get => sub { } );
 
 subtest "Simple Storing" => sub {
     
-    plan tests => 3;
+    plan tests => 5;
     
     my $rqst_normal = $rqst_minimal->clone;
     $rqst_normal->uri($URI_LOCATION);
@@ -44,13 +44,23 @@ subtest "Simple Storing" => sub {
     # don't care about responses, we only want to store in the cache
     $http_caching->make_request($rqst_normal);
     
+    is (keys %cache, 2,
+        'there are 2 items in the cache');
+    
     ok (exists $cache{$URI_MD5}, 
         'stored under the right key');
     
-    isa_ok ($cache{$URI_MD5}, 'HTTP::Response',
+    my @meta_keys = keys $cache{$URI_MD5};
+    
+    isa_ok ($cache{$meta_keys[0]}, 'HTTP::Response',
         '... a HTTP::Request object');
     
-    is ($cache{$URI_MD5}->content, 'Who is there?',
-        '... with the right contnet');
+    is ($cache{$meta_keys[0]}->content, 'Who is there?',
+        '... with the right content');
+    
+    $http_caching->make_request($rqst_normal);
+
+    is (keys %cache, 3,
+        'we store every response that _may_store_in_cache');
     
 };

--- a/t/03_retrieve_response.t
+++ b/t/03_retrieve_response.t
@@ -11,6 +11,7 @@ use Readonly;
 # Although it does look like a proper URI, no, the file does not need to exist.
 Readonly my $URI_LOCATION   => 'file:///tmp/HTTP_Cacing/greetings.txt';
 Readonly my $URI_MD5        => '7d3d0fc115036f144964caafaf2c7df2';
+Readonly my $CONTENT_KEY    => '3e5f1b953da8430c6f88b90ac15d78fa'; # or whatever
 
 # mock cache
 my %cache;
@@ -27,7 +28,8 @@ my $expected_resp = HTTP::Response->new(501);
 $expected_resp->content('Who is there?');
 
 # populate the cache, we could try mocking CHI, but I'm to lazy for that
-$cache{$URI_MD5} = $expected_resp;
+$cache{$CONTENT_KEY} = $expected_resp;
+$cache{$URI_MD5} = { $CONTENT_KEY => undef };
 
 my $http_caching = HTTP::Caching->new(
     cache                   => $mocked_cache,

--- a/t/03_retrieve_response.t
+++ b/t/03_retrieve_response.t
@@ -1,6 +1,8 @@
 use Test::Most tests => 1;
 use Test::MockObject;
 
+use Carp;
+
 use HTTP::Caching;
 
 use HTTP::Request;
@@ -13,16 +15,18 @@ Readonly my $URI_LOCATION   => 'file:///tmp/HTTP_Cacing/greetings.txt';
 Readonly my $URI_MD5        => '7d3d0fc115036f144964caafaf2c7df2';
 Readonly my $CONTENT_KEY    => '3e5f1b953da8430c6f88b90ac15d78fa'; # or whatever
 
+my $rqst_minimal = HTTP::Request->new('HEAD');
+my $resp_minimal = HTTP::Response->new(100);
+
 # mock cache
 my %cache;
 my $mocked_cache = Test::MockObject->new;
 $mocked_cache->mock( set => sub { } );
 $mocked_cache->mock( get => sub { return $cache{$_[1]} } );
 
-my $request = HTTP::Request->new();
-$request->method('TEST'); # yep, does not exists, thats fine
-$request->uri($URI_LOCATION);
-$request->content('knock knock ...');
+my $rqst_normal = $rqst_minimal->clone;
+$rqst_normal->uri($URI_LOCATION);
+$rqst_normal->content('knock knock ...');
 
 my $expected_resp = HTTP::Response->new(501);
 $expected_resp->content('Who is there?');
@@ -34,10 +38,10 @@ $cache{$URI_MD5} = { $CONTENT_KEY => undef };
 my $http_caching = HTTP::Caching->new(
     cache                   => $mocked_cache,
     cache_type              => 'private',
-    forwarder               => sub { die "we shouldn't be here!" }
+    forwarder               => sub { "we shouldn't be here!" }
 );
 
-my $response = $http_caching->make_request($request);
+my $response = $http_caching->make_request($rqst_normal);
 
 is ( $response->content(), 'Who is there?',
     "Got the expected response back");

--- a/t/04_naive_roundtrip.t
+++ b/t/04_naive_roundtrip.t
@@ -12,22 +12,26 @@ use Readonly;
 Readonly my $URI_LOCATION   => 'file:///tmp/HTTP_Cacing/greetings.txt';
 Readonly my $URI_MD5        => '7d3d0fc115036f144964caafaf2c7df2';
 
+my $rqst_minimal = HTTP::Request->new('HEAD');
+my $resp_minimal = HTTP::Response->new(100);
+
 # mock cache
 my %cache;
 my $mocked_cache = Test::MockObject->new;
 $mocked_cache->mock( set => sub { $cache{$_[1]} = $_[2] } );
 $mocked_cache->mock( get => sub { return $cache{$_[1]} } );
 
-my $request = HTTP::Request->new();
-$request->method('HEAD');
-$request->uri($URI_LOCATION);
-$request->content('knock knock ...');
+my $rqst_normal = $rqst_minimal->clone;
+$rqst_normal->uri($URI_LOCATION);
+$rqst_normal->content('knock knock ...');
 
 # 501 Not Implemented is a 'by default' cachable response
-my $forwarded_resp = HTTP::Response->new(501);
-$forwarded_resp->content('Who is there?');
+my $resp_normal = $resp_minimal->clone;
+$resp_normal->code(501);
+$resp_normal->content('Who is there?');
 
 my $forwarded_rqst = undef; # flag to be set if we do forward the request
+my $forwarded_resp = $resp_normal;
 
 my $http_caching = HTTP::Caching->new(
     cache                   => $mocked_cache,
@@ -38,7 +42,7 @@ my $http_caching = HTTP::Caching->new(
     }
 );
 
-my $response_one = $http_caching->make_request($request);
+my $response_one = $http_caching->make_request($rqst_normal);
 is ($forwarded_rqst->content(), 'knock knock ...',
     "Request has been forwarded");
 is ($response_one->content(), 'Who is there?',
@@ -46,7 +50,7 @@ is ($response_one->content(), 'Who is there?',
 
 $forwarded_rqst = undef;
 
-my $response_two = $http_caching->make_request($request);
+my $response_two = $http_caching->make_request($rqst_normal);
 is ($forwarded_rqst, undef,
     "Request has not been forwarded for the second time");
 is ($response_two->content(), 'Who is there?',

--- a/t/04_naive_roundtrip.t
+++ b/t/04_naive_roundtrip.t
@@ -11,7 +11,6 @@ use Readonly;
 # Although it does look like a proper URI, no, the file does not need to exist.
 Readonly my $URI_LOCATION   => 'file:///tmp/HTTP_Cacing/greetings.txt';
 Readonly my $URI_MD5        => '7d3d0fc115036f144964caafaf2c7df2';
-Readonly my $CONTENT_KEY    => '3e5f1b953da8430c6f88b90ac15d78fa'; # or whatever
 
 # mock cache
 my %cache;


### PR DESCRIPTION
We can have multiple responses with the same URI.

This will now allow to store a separate dictionary that holds the key to the stored response, along with a (stripped) HTTP::Response and HTTP::Request