### PR TITLE
cache-control directives Maybe ['Str']

### DIFF
--- a/lib/HTTP/Caching.pm
+++ b/lib/HTTP/Caching.pm
@@ -10,7 +10,7 @@ Version 0.05
 
 =cut
 
-our $VERSION = '0.08';
+our $VERSION = '0.09';
 
 use strict;
 use warnings;
@@ -94,13 +94,13 @@ has cache_type => (
 has cache_control_request => (
     is          => 'ro',
     required    => 0,
-    isa         => Str,
+    isa         => Maybe[ Str ],
 );
 
 has cache_control_response => (
     is          => 'ro',
     required    => 0,
-    isa         => Str,
+    isa         => Maybe[ Str ],
 );
 
 has forwarder => (
@@ -307,7 +307,7 @@ sub make_request {
      # add the default Cache-Control response header-field
     $response->headers->push_header(
         cache_control => $self->cache_control_response,
-    ) if $self->cache_control_request;
+    ) if $self->cache_control_response;
    
     return $response;
     

--- a/t/01_modify_cache_control_headers.t
+++ b/t/01_modify_cache_control_headers.t
@@ -6,7 +6,7 @@ use HTTP::Request;
 use HTTP::Response;
 
 subtest 'Simple modifiactions' => sub {
-    plan tests => 5;
+    plan tests => 6;
     
     
     my $request = HTTP::Request->new();
@@ -15,6 +15,16 @@ subtest 'Simple modifiactions' => sub {
     
     my $forwarded_resp = HTTP::Response->new(501);
     my $forwarded_rqst;
+
+    my $http_caching_undefs =
+        new_ok('HTTP::Caching', [
+            cache                   => undef, # no cache needed for these tests
+            cache_type              => undef,
+            cache_control_request   => undef,
+            cache_control_response  => undef,
+            forwarder               => sub { },
+        ] , 'my $http_caching_undefs'
+    );
     
     my $http_caching =
         new_ok('HTTP::Caching', [


### PR DESCRIPTION
and related bug

it should be totally fine to pass undef to the cache for either string